### PR TITLE
Support for Island Adventure's port of DS DLC seasons in DST.

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -276,17 +276,17 @@ if DST and SHOWSTATNUMBERS and GLOBAL.kleifileexists("scripts/widgets/wandaageba
 end
 
 local function FindSeasonTransitions()
-    if DST then
-        local seasons_trans = {"autumn", "winter", "spring", "summer"}
-        --IsShipwreckedWorld and IsPorkWorld are defined in Island Adventures.
-        if HAS_MOD.ISLAND_ADVENTURES then --This can all be one tertiary, but for claritys sake I made this its own statement
-            return GLOBAL.IsShipwreckedWorld() and {"mild", "wet", "green", "dry"}
-                or GLOBAL.IsPorkWorld() and {"temperate", "humid", "lush"}
-                or seasons_trans
-        end
+	if DST then
+		local seasons_trans = {"autumn", "winter", "spring", "summer"}
+		--IsShipwreckedWorld and IsPorkWorld are defined in Island Adventures.
+		if HAS_MOD.ISLAND_ADVENTURES then --This can all be one tertiary, but for claritys sake I made this its own statement
+			return GLOBAL.IsShipwreckedWorld() and {"mild", "wet", "green", "dry"}
+				or GLOBAL.IsPorkWorld() and {"temperate", "humid", "lush"}
+				or seasons_trans
+		end
 
-        return seasons_trans
-    end
+		return seasons_trans
+	end
 	local season_trans = {}
 	-- scrape the SeasonManager's length data to see what seasons are enabled (covers Hamlet, Shipwrecked, RoG, Vanilla)
 	local longest_season_str = 0

--- a/modmain.lua
+++ b/modmain.lua
@@ -69,9 +69,13 @@ for k,v in pairs(GLOBAL.KnownModIndex:GetModsToLoad()) do
 	if mod_type then
 		HAS_MOD[mod_type] = v
 	end
-	-- Have to special-case this check because there are so many variants of RPG HUD that this is really the best way to check
-    if string.match(GLOBAL.KnownModIndex:GetModInfo(v).name or "", "RPG HUD") then
+	
+    local modinfo = GLOBAL.KnownModIndex:GetModInfo(v)
+    -- Have to special-case this check because there are so many variants of RPG HUD that this is really the best way to check
+    if string.match(modinfo.name or "", "RPG HUD") then
 		HAS_MOD.RPGHUD = true
+    elseif modinfo.ia_core then --For Shipwrecked and Hamlet port mods (They make use of a single core mod)
+        HAS_MOD.ISLAND_ADVENTURES = true
     end
 end
 
@@ -272,7 +276,17 @@ if DST and SHOWSTATNUMBERS and GLOBAL.kleifileexists("scripts/widgets/wandaageba
 end
 
 local function FindSeasonTransitions()
-	if DST then return {"autumn", "winter", "spring", "summer"} end
+    if DST then
+        local seasons_trans = {"autumn", "winter", "spring", "summer"}
+        --IsShipwreckedWorld and IsPorkWorld are defined in Island Adventures.
+        if HAS_MOD.ISLAND_ADVENTURES then --This can all be one tertiary, but for claritys sake I made this its own statement
+            return GLOBAL.IsShipwreckedWorld() and {"mild", "wet", "green", "dry"}
+                or GLOBAL.IsPorkWorld() and {"temperate", "humid", "lush"}
+                or seasons_trans
+        end
+
+        return seasons_trans
+    end
 	local season_trans = {}
 	-- scrape the SeasonManager's length data to see what seasons are enabled (covers Hamlet, Shipwrecked, RoG, Vanilla)
 	local longest_season_str = 0


### PR DESCRIPTION
Island Adventures is getting a full rewrite with it's seasons being their own proper seasons (from the original method of the regular seasons being modified for the Shipwrecked dangers) and Hamlet soon to be.

This does NOT yet contain support for the Aporkalypse season, this will come at a later time.