### PR TITLE
fix WX health display after WX skill tree update

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -113,13 +113,29 @@ local function BadgePostConstruct(self)
 	self.bg:SetPosition(-.5, -40, 0)
 	
 	self.num:SetFont(GLOBAL.NUMBERFONT)
-	self.num:SetSize(SHOWDETAILEDSTATNUMBERS and 20 or 28)
-	self.num:SetPosition(2, -40.5, 0)
-	self.num:SetScale(1,.78,1)
+	local function UpdatePositionAndScale(badge)
+		if not badge.num then return end
+
+		badge.num:SetSize(SHOWDETAILEDSTATNUMBERS and 20 or 28)
+		badge.num:SetPosition(2, -40.5, 0)
+		badge.num:SetScale(1,.78,1)
+	end
+	UpdatePositionAndScale(self)
 
 	self.num:MoveToFront()
 	if self.active then
 		self.num:Show()
+	end
+
+	if self.UpdateNums then -- only called for health
+		local _UpdateNums = self.UpdateNums
+		self.UpdateNums = function (self, ...)
+			_UpdateNums(self, ...)
+			UpdatePositionAndScale(self)
+			if self.focus and self.wxshieldanimnum then
+				self.wxshieldanimnum:Hide()
+			end
+		end
 	end
 
 	badges[self] = self
@@ -131,6 +147,9 @@ local function BadgePostConstruct(self)
 	local OldOnGainFocus = self.OnGainFocus
 	function self:OnGainFocus()
 		OldOnGainFocus(self)
+		if self.wxshieldanimnum then
+			self.wxshieldanimnum:Hide()
+		end
 		if self.active then
 			self.maxnum:Show()
 		end
@@ -140,6 +159,9 @@ local function BadgePostConstruct(self)
 	function self:OnLoseFocus()
 		OldOnLoseFocus(self)
 		self.maxnum:Hide()
+		if self.wxshieldanimnum and self.wxshieldanimflicker.shown then
+			self.wxshieldanimnum:Show()
+		end
 		if self.active then
 			self.num:Show()
 		end


### PR DESCRIPTION
fixes #38

After the recent (April 16) WX skill tree update, the health display for wx broke because of a shield health ability added to the beanbooster circuit (with the Alpha Circuits Tinkering 2 skill active).

I wasn't sure on the best UX for when WX has shield, as adding it into the box below the heart seemed a bit intrusive. I've settled on always showing the shield health in its default position on the heart, and hiding the shield health when the heart is hovered (so it doesn't overlap with the max health display)


Before:
<img width="217" height="103" alt="image" src="https://github.com/user-attachments/assets/570b3971-62b7-44c3-b3f9-0bfef0f071b6" />


After:

<img width="217" height="103" alt="image" src="https://github.com/user-attachments/assets/6791fead-e27c-411f-8336-36bccffb84d8" />
