### PR TITLE
Support for the Aporkalypse in IA Hamlet

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -303,7 +303,7 @@ local function FindSeasonTransitions()
 		--IsShipwreckedWorld and IsPorkWorld are defined in Island Adventures.
 		if HAS_MOD.ISLAND_ADVENTURES then --This can all be one tertiary, but for claritys sake I made this its own statement
 			return GLOBAL.IsShipwreckedWorld() and {"mild", "wet", "green", "dry"}
-				or GLOBAL.IsPorkWorld() and {"temperate", "humid", "lush"}
+				or GLOBAL.IsPorkWorld() and {"temperate", "humid", "lush", "aporkalypse"}
 				or seasons_trans
 		end
 

--- a/scripts/widgets/seasonclock.lua
+++ b/scripts/widgets/seasonclock.lua
@@ -307,22 +307,16 @@ function SeasonClock:GetSeasonLengths()
 	return lengths
 end
 
-function SeasonClock:OnSeasonLengthsChanged(data)
-	--Technically this misbehaves a little if there's a short initial season
-	-- followed by an endless season; it only displays the endless season
-	--However, I'm leaving this behavior in because a solution would be messy and potentially ambiguous
-	if data == nil then
-		data = self:GetSeasonLengths()
-	end
+function SeasonClock:CalculateSegmentColors(season_lengths)
 	local lengths = {}
 	local total = 0
-	for k,v in pairs(data) do
+	for k,v in pairs(season_lengths) do
 		total = total + v
 	end
 	local multiplier = NUM_SEGS/total
 	local residuals = {}
 	total = 0
-	for k,v in pairs(data) do
+	for k,v in pairs(season_lengths) do
 		local length = v*multiplier
 		lengths[k] = math.floor(length)
 		total = total + lengths[k]
@@ -356,6 +350,23 @@ function SeasonClock:OnSeasonLengthsChanged(data)
 
 		seg:SetTint(color.x, color.y, color.z, 1)
     end
+end
+
+function SeasonClock:OnSeasonLengthsChanged(data)
+	--Technically this misbehaves a little if there's a short initial season
+	-- followed by an endless season; it only displays the endless season
+	--However, I'm leaving this behavior in because a solution would be messy and potentially ambiguous
+	if data == nil then
+		data = self:GetSeasonLengths()
+	end
+	-- asgerrr: for IA-side practical reasons, the pre-aporkalypse season is not networked, so something else must be done. i also happen to prefer that the clock shows something useful during aporkalypse
+	if self._dst and TheWorld.state.isaporkalypse then
+		data.temperate = 0
+		data.humid = 0
+		data.lush = 0
+	end
+	self:CalculateSegmentColors(data)
+
 	-- Although the seasons component pushes a seasontick after seasonlengthschanged,
 	-- the delay we have on the event listener can cause them to get out of order
 	-- since it's not really that expensive, just run it again to ensure it has the right numbers
@@ -367,7 +378,7 @@ function SeasonClock:OnCyclesChanged(data)
 	local i = 1
 	local season = self._dst and TheWorld.state.season or GetSeasonManager():GetSeason()
 	local aporkalypse = false
-	if SEASONS.APORKALYPSE and season == SEASONS.APORKALYPSE then
+	if not self._dst and SEASONS.APORKALYPSE and season == SEASONS.APORKALYPSE then
 		-- Aporkalypse doesn't have a place on the clock, so use the previous "paused" season
 		season = GetSeasonManager().pre_aporkalypse_season or SEASONS.TEMPERATE
 		aporkalypse = true

--- a/scripts/widgets/seasonclock.lua
+++ b/scripts/widgets/seasonclock.lua
@@ -361,9 +361,9 @@ function SeasonClock:OnSeasonLengthsChanged(data)
 	end
 	-- asgerrr: for IA-side practical reasons, the pre-aporkalypse season is not networked, so something else must be done. i also happen to prefer that the clock shows something useful during aporkalypse
 	if self._dst and TheWorld.state.isaporkalypse then
-		data.temperate = 0
-		data.humid = 0
-		data.lush = 0
+		for season, _ in data do
+			if season ~= "aporkalypse" then data[season] = 0 end
+		end
 	end
 	self:CalculateSegmentColors(data)
 


### PR DESCRIPTION
This PR adds support for the Aporkalypse in IA Hamlet. The way the mod currently works, it takes a solo DS-only code path during the Aporkalypse and crashes. The fix I've chosen to write here does not work exactly like the mod does things in solo DS. Instead, it hides all other seasons during the Aporkalypse, instead using the clock to show how much of the Aporkalypse season is left. This is because the pre_aporkalypse_season variables are not networked in IA Hamlet, so the information required to show the pre-Aporkalypse season like in solo DS is not available. If I really wanted to, I could have made those variables networked in IA, but I honestly like things better this way.